### PR TITLE
Refactor repository count methods to handle string or number types

### DIFF
--- a/src/core/base.repository.ts
+++ b/src/core/base.repository.ts
@@ -54,8 +54,8 @@ export abstract class BaseRepository<T> {
     if (where) {
       countSql += ' WHERE ' + where;
     }
-    const countResult = await this.db.query<{ total: number }>(countSql, params);
-    const total = countResult.rows[0]?.total || 0;
+    const countResult = await this.db.query<{ total: string | number }>(countSql, params);
+    const total = Number(countResult.rows[0]?.total || 0);
 
     // Pagination
     if (options?.limit && options?.page) {

--- a/src/modules/post/post.repository.ts
+++ b/src/modules/post/post.repository.ts
@@ -66,8 +66,8 @@ export class PostRepository extends BaseRepository<Post> {
       countSql += ' WHERE ' + where;
     }
 
-    const countResult = await this.db.query<{ total: number }>(countSql, params);
-    const total = countResult.rows[0]?.total || 0;
+    const countResult = await this.db.query<{ total: string | number }>(countSql, params);
+    const total = Number(countResult.rows[0]?.total || 0);
 
     // Pagination
     if (options?.limit && options?.page) {

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -51,7 +51,7 @@ export class UserRepository extends BaseRepository<User> {
 
   async countByRole(role: Role): Promise<number> {
     const sql = `SELECT COUNT(*) as count FROM ${this.tableName} WHERE role = ${QueryBuilder.createPlaceholder(0)}`;
-    const result = await this.executeQuery<{ count: number }>(sql, [role]);
-    return result.rows[0]?.count || 0;
+    const result = await this.executeQuery<{ count: string | number }>(sql, [role]);
+    return Number(result.rows[0]?.count || 0);
   }
 }

--- a/tests/e2e/posts.e2e.test.ts
+++ b/tests/e2e/posts.e2e.test.ts
@@ -81,6 +81,8 @@ describe('Posts E2E Tests', () => {
 
       expect(response.body.success).toBe(true);
       expect(response.body.data).toHaveLength(1);
+      expect(response.body.meta.total).toBe(1);
+      expect(typeof response.body.meta.total).toBe('number');
       expect(response.body.data[0].author.name).toBe('Regular User');
     });
 
@@ -91,6 +93,8 @@ describe('Posts E2E Tests', () => {
         .expect(200);
 
       expect(response.body.data).toHaveLength(1);
+      expect(response.body.meta.total).toBe(1);
+      expect(typeof response.body.meta.total).toBe('number');
     });
   });
 

--- a/tests/e2e/users.e2e.test.ts
+++ b/tests/e2e/users.e2e.test.ts
@@ -75,6 +75,8 @@ describe('Users E2E Tests', () => {
       // Assert
       expect(response.body.success).toBe(true);
       expect(response.body.data).toHaveLength(2);
+      expect(response.body.meta.total).toBe(2);
+      expect(typeof response.body.meta.total).toBe('number');
     });
 
     it('should return 403 for non-admin users', async () => {

--- a/tests/integration/repositories/post.repository.test.ts
+++ b/tests/integration/repositories/post.repository.test.ts
@@ -107,6 +107,8 @@ describe('PostRepository Integration Tests', () => {
 
       // Assert
       expect(result.data).toHaveLength(2);
+      expect(result.meta.total).toBe(2);
+      expect(typeof result.meta.total).toBe('number');
       expect(result.data[0]!.author).toBeDefined();
       expect(result.data[0]!.author.id).toBe(testUser.id);
       expect(result.data[0]!.author.name).toBe('Test Author');

--- a/tests/integration/repositories/user.repository.test.ts
+++ b/tests/integration/repositories/user.repository.test.ts
@@ -1,6 +1,6 @@
-import { UserRepository } from '@/user/user.repository';
 import { DatabaseConnection } from '@/database/connection';
 import { Role } from '@/types/role.enum';
+import { UserRepository } from '@/user/user.repository';
 
 describe('UserRepository Integration Tests', () => {
   let userRepository: UserRepository;
@@ -123,6 +123,8 @@ describe('UserRepository Integration Tests', () => {
 
       // Assert
       expect(result.data).toHaveLength(2);
+      expect(result.meta.total).toBe(3);
+      expect(typeof result.meta.total).toBe('number');
       expect(result.meta).toEqual({
         page: 1,
         limit: 2,
@@ -153,11 +155,11 @@ describe('UserRepository Integration Tests', () => {
       }
 
       // Act
-      const result = await userRepository.findAll({ 
-        page: 1, 
-        limit: 10, 
-        sortBy: 'name', 
-        sortOrder: 'ASC' 
+      const result = await userRepository.findAll({
+        page: 1,
+        limit: 10,
+        sortBy: 'name',
+        sortOrder: 'ASC',
       });
 
       // Assert
@@ -194,7 +196,9 @@ describe('UserRepository Integration Tests', () => {
       expect(updatedUser!.name).toBe(updateData.name);
       expect(updatedUser!.role).toBe(updateData.role);
       expect(updatedUser!.email).toBe(userData.email); // Should not change
-      expect(updatedUser!.updatedAt.getTime()).toBeGreaterThanOrEqual(createdUser.updatedAt.getTime());
+      expect(updatedUser!.updatedAt.getTime()).toBeGreaterThanOrEqual(
+        createdUser.updatedAt.getTime()
+      );
     });
 
     it('should return null when updating non-existent user', async () => {
@@ -334,7 +338,7 @@ describe('UserRepository Integration Tests', () => {
     it('should return empty array for non-existent role', async () => {
       // Act - Note: we can't test non-existent role with enum, so skip this test
       // const users = await userRepository.findByRole('nonexistent');
-      
+
       // Act with valid role but no data
       const users = await userRepository.findByRole(Role.ADMIN);
 
@@ -398,4 +402,4 @@ describe('UserRepository Integration Tests', () => {
       expect(updatedUser!.updatedAt.getTime()).toBeGreaterThanOrEqual(originalUpdatedAt.getTime());
     });
   });
-}); 
+});


### PR DESCRIPTION
- Updated count methods in BaseRepository, PostRepository, and UserRepository to accept and convert total counts from string or number types to ensure consistent number handling.
- Enhanced E2E and integration tests to validate the type of total counts returned in responses, improving test coverage and reliability.